### PR TITLE
TypeHandler now handles NULL values for non-array fields.

### DIFF
--- a/src/Attribute.php
+++ b/src/Attribute.php
@@ -77,7 +77,6 @@ class Attribute extends \ArrayObject
     public function setValue($value, $lang = self::LANGUAGE_DEFAULT)
     {
         $this['value'][$lang] = $this->getTypeHandler()->set($value);
-    }
         return $this;
     }
 

--- a/src/Attribute.php
+++ b/src/Attribute.php
@@ -76,9 +76,8 @@ class Attribute extends \ArrayObject
      */
     public function setValue($value, $lang = self::LANGUAGE_DEFAULT)
     {
-        if ($value !== NULL) {
-            $this['value'][$lang] = $this->getTypeHandler()->set($value);
-        }
+        $this['value'][$lang] = $this->getTypeHandler()->set($value);
+    }
         return $this;
     }
 

--- a/src/TypeHandler.php
+++ b/src/TypeHandler.php
@@ -70,6 +70,14 @@ class TypeHandler
         else {
             if ($value !== NULL) {
                 settype($value, $this->getCast());
+            } elseif ($this->getType() == Attribute::TYPE_STRING) {
+                return "";
+            } elseif ($this->getType() == Attribute::TYPE_INTEGER) {
+                return 0;
+            } elseif ($this->getType() == Attribute::TYPE_NUMBER) {
+                return 0.0;
+            } elseif ($this->getType() == Attribute::TYPE_REFERENCE) {
+                return "";
             }
         }
         return $value;


### PR DESCRIPTION
The pull request addresses the issue of empty fields of an entity are not represented in the generated CDF.

Turned out they were intentionally left out because we did not want to see "null" values in the CDF. This pull request extends the TypeHandler and adds default values for different non-array types that are be to put in the CDF in case of a NULL value in the relevant field of the drupal entity.

I created the pull request to prevent this patch to be forgotten, but there is still some work to do with it:
- Someone with more experience then me needs to review this change if this will not  confict with some other usecase of the TypeHandler class. An alternative solution could be to check if the value of the property is NULL in the content-hub-connector module/CDF/ParseDrupalEntity() and if yes, set a valid, non-NULL empty value manually regarding to the type of the property. I felt this to be a "hack" since I think these kind of stuff belongs to the TypeHandler, but I'm not positive.
- I have not written any test cases that checks if the solution works as expected
- I have not run the test suite to make sure I did not introduce any bugs.