### PR TITLE
Initial support for hmac 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@ bootstrap.php
 build
 vendor
 composer.lock
-
+.idea
 nbproject

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": ">=5.5.0",
         "guzzlehttp/guzzle": "~6.0",
-        "acquia/http-hmac-php": "~2.1",
+        "acquia/http-hmac-php": "~3.1",
         "symfony/serializer": "~2.7",
         "symfony/http-foundation": "~2.7"
     },

--- a/src/ContentHub.php
+++ b/src/ContentHub.php
@@ -4,6 +4,7 @@ namespace Acquia\ContentHubClient;
 
 use Acquia\Hmac\Digest as Digest;
 use Acquia\Hmac\Guzzle\HmacAuthMiddleware;
+use Acquia\Hmac\Key;
 use Acquia\Hmac\RequestSigner;
 use Psr\Http\Message\RequestInterface;
 use GuzzleHttp\Client;
@@ -12,6 +13,12 @@ use GuzzleHttp\Psr7\Request;
 
 class ContentHub extends Client
 {
+    /**
+     * @var \Acquia\Hmac\KeyInterface
+     *   A sample key.
+     */
+    protected $authKey;
+
     /**
      * Overrides \GuzzleHttp\Client::__construct()
      *
@@ -32,15 +39,24 @@ class ContentHub extends Client
         $config['headers']['Content-Type'] = 'application/json';
         $config['headers']['X-Acquia-Plexus-Client-Id'] = $origin;
 
-        // Add the authentication handler
-        // @see https://github.com/acquia/http-hmac-spec
-        $requestSigner = new RequestSigner(new Digest\Version1('sha256'));
-        $middleware = new HmacAuthMiddleware($requestSigner, $apiKey, $secretKey);
+        // A key consists of your UUID and a MIME base64 encoded shared secret.
+        $this->authKey = new Key($apiKey, $secretKey);
 
+        // Set our default HandlerStack if nothing is provided
         if (!isset($config['handler'])) {
             $config['handler'] = HandlerStack::create();
         }
-        $config['handler']->push($middleware);
+
+        // Add the authentication handler
+        // @see https://github.com/acquia/http-hmac-spec
+        if (isset($config['auth_middleware'])) {
+            if ($config['auth_middleware'] !== false) {
+                $config['handler']->push($config['auth_middleware']);
+            }
+        } else {
+            $middleware = new HmacAuthMiddleware($this->authKey, 'ContentHub');
+            $config['handler']->push($middleware);
+        }
 
         parent::__construct($config);
     }

--- a/test/ContentHubTest.php
+++ b/test/ContentHubTest.php
@@ -18,7 +18,7 @@ class ContentHubTest extends \PHPUnit_Framework_TestCase
     {
         $mock = new MockHandler($responses);
         $stack = HandlerStack::create($mock);
-        return new ContentHub('public', 'secret', 'origin', ['handler' => $stack]);
+        return new ContentHub('public', 'secret', 'origin', ['handler' => $stack, 'auth_middleware' => false]);
     }
 
     private function setData()

--- a/test/SettingsTest.php
+++ b/test/SettingsTest.php
@@ -19,7 +19,7 @@ class SettingsTest extends \PHPUnit_Framework_TestCase
     {
       $mock = new MockHandler($responses);
       $stack = HandlerStack::create($mock);
-      return new ContentHub('public', 'secret', 'origin', ['handler' => $stack]);
+      return new ContentHub('public', 'secret', 'origin', ['handler' => $stack, 'auth_middleware' => false]);
     }
 
     private function setData()


### PR DESCRIPTION
Today I wanted to test our new Lift SDK for PHP (https://github.com/acquia/lift-sdk-php) and I noticed the following conflict:

content-hub-php is using http-hmac-php v2.1.x
lift-sdk-php requires http-hmac-php v3.1.x (because we need http-hmac-spec v2.0 support which got added in 3.x.x)
Composer is getting annoyed by this and fails to cooperate nicely together. I am not really seeing a solution here that can quickly solve this other than updating the content-hub-php SDK library to http-hmac-php v3.1.x. Is this something I can just take on and as long as the unit tests work we should be fine?

The consequence of this issue is that Acquia Lift is unable to release a Lift Module that works in tandem with the Content Hub module until this is resolved.
