### PR TITLE
Enable synchronous entity creation

### DIFF
--- a/src/ContentHub.php
+++ b/src/ContentHub.php
@@ -134,7 +134,7 @@ class ContentHub extends Client
     }
 
     /**
-     * Sends request to asynchronously create an entity.
+     * Sends request to create an entity.
      *
      * The entity does not need to be passed to this method, but only the resource URL.
      *
@@ -143,37 +143,45 @@ class ContentHub extends Client
      * @param  string $resource
      *   This string should contain the URL where Plexus can read the entity's CDF.
      *
+     * @param  object $entities
+     *   This optionally sends entities to Content Hub synchronously.
+     *
      * @return \Psr\Http\Message\ResponseInterface
      *
      * @throws \GuzzleHttp\Exception\RequestException
      */
-    public function createEntity($resource)
+    public function createEntity($resource, $entities = NULL)
     {
-      return $this->createEntities($resource);
+      return $this->createEntities($resource, $entities);
     }
 
     /**
-     * Sends request to asynchronously create entities.
+     * Sends request to create entities.
      *
      * The entity does not need to be passed to this method, but only the resource URL.
      *
      * @param  string $resource
      *   This string should contain the URL where Plexus can read the entities' CDF.
      *
+     * @param  object $entities
+     *   This optionally sends entities to Content Hub synchronously.
+     *
      * @return \Psr\Http\Message\ResponseInterface
      *
      * @throws \GuzzleHttp\Exception\RequestException
      */
-    public function createEntities($resource)
+    public function createEntities($resource, $entities = NULL)
     {
         $json = [
             'resource' => $resource,
         ];
+        if (!empty($entities)) {
+            $json['data'] = $entities;
+        }
         $body = json_encode($json);
         $endpoint = "/{$this->api_version}/entities";
         $request = new Request('POST', $endpoint, [], $body);
-        $response = $this->send($request);
-        return $response;
+        return $this->getResponseJson($request);
     }
 
     /**


### PR DESCRIPTION
Small patch that enables synchronous entity creation. I needed this for a command line implementation where the async callback approach would not work.

Default async implementations will continue work, e.g.

`$client = new ContentHub(...);
$resourceUrl = 'http://example.com/path/to/cdf';
$client->createEntities($resourceUrl);
`

You can now pass an optional second $entities argument to create synchronously, e.g.

`$client = new ContentHub(...);
$entities = new Entities();
$entities->addEntity(...);
$request = $client->createEntities(NULL, $entities);
`

The createEntities() function also now returns $this->getResponseJson() for a meaningful message, in line with other functions in the class.