### PR TITLE
LCH-2395: Add raw search criteria to a proprietary HTTP header before relaying the request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,7 @@ build
 vendor
 composer.lock
 
+.DS_Store
+
 nbproject
 .idea

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "symfony/http-foundation": "~2.7|^3.2",
         "symfony/event-dispatcher": "~2.7|^3.2",
         "acquia/http-hmac-php": "~3.4|~4.0",
-        "psr/log": "~1.0"
+        "psr/log": "~1.0",
+        "ext-json": "*"
     },
     "require-dev": {
         "pdepend/pdepend": "~1.0",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "issues": "https://github.com/acquia/content-hub-php/issues"
     },
     "require": {
-        "php": ">=5.6",
+        "php": ">=7.1",
         "guzzlehttp/guzzle": "~6.0",
         "symfony/serializer": "~2.7|^3.2",
         "symfony/http-foundation": "~2.7|^3.2",

--- a/src/ContentHubClient.php
+++ b/src/ContentHubClient.php
@@ -983,7 +983,7 @@ class ContentHubClient extends Client
             }
             $args[0] = self::makePath(...$parts);
 
-            $args = $this->addSearchCriteriaHeader($args);
+            $args = $this->addSearchCriteriaHeader($args, $this->getConfig(self::OPTION_NAME_LANGUAGES));
 
             return parent::__call($method, $args);
         } catch (\Exception $e) {
@@ -1206,16 +1206,18 @@ class ContentHubClient extends Client
         $config['handler']->push(new RequestResponseHandler($this->logger));
     }
 
-    /**
-     * Appends search criteria header.
-     *
-     * @param array $args
-     *   Method arguments.
-     *
-     * @return array
-     *   Processed arguments.
-     */
-    protected function addSearchCriteriaHeader(array $args): array
+  /**
+   * Appends search criteria header.
+   *
+   * @param array $args
+   *   Method arguments.
+   *
+   * @param mixed $languages
+   *
+   * @return array
+   *   Processed arguments.
+   */
+    protected function addSearchCriteriaHeader(array $args, $languages): array
     {
         [, $queryString] = explode('?', $args[0] ?? '');
 
@@ -1224,8 +1226,6 @@ class ContentHubClient extends Client
         }
 
         parse_str($queryString, $parsedQueryString);
-
-        $languages = $this->getConfig(self::OPTION_NAME_LANGUAGES);
 
         if (!empty($languages) && is_array($languages)) {
             $parsedQueryString['languages'] = $languages;

--- a/src/SearchCriteria/Transformer.php
+++ b/src/SearchCriteria/Transformer.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Acquia\ContentHubClient\SearchCriteria;
+
+use Acquia\ContentHubClient\CDF\CDFObject;
+
+/**
+ * Class SearchCriteria
+ *
+ * @package Drupal\acquia_contenthub\Client
+ */
+class Transformer {
+  public static $supported_keys = [
+      'search_term' => [
+        'possible_keys' => ['search_term'],
+        'default_value' => 'drupal8_content_entity',
+      ],
+      'type' => [
+        'possible_keys' => ['type'],
+        'default_value' => [],
+      ],
+      'bundle' => [
+        'possible_keys' => ['bundle'],
+        'default_value' => [],
+      ],
+      'tags' => [
+        'possible_keys' => ['tags'],
+        'default_value' => [],
+      ],
+      'label' => [
+        'possible_keys' => ['label'],
+        'default_value' => '',
+      ],
+      'start_date' => [
+        'possible_keys' => ['start_date'],
+        'default_value' => NULL,
+      ],
+      'end_date' => [
+        'possible_keys' => ['end_date'],
+        'default_value' => NULL,
+      ],
+      'from' => [
+        'possible_keys' => ['from', 'start'],
+        'default_value' => 0,
+      ],
+      'size' => [
+        'possible_keys' => ['size', 'limit'],
+        'default_value' => 1000,
+      ],
+      'sorting' => [
+        'possible_keys' => ['sort'],
+        'default_value' => '',
+      ],
+      'version' => [
+        'possible_keys' => ['version'],
+        'default_value' => '2.0',
+      ],
+      'languages' => [
+        'possible_keys' => ['languages'],
+        'default_value' => [CDFObject::LANGUAGE_UNDETERMINED],
+      ],
+    ];
+
+  /**
+   * @param array $data
+   *
+   * @return array
+   */
+  public static function arrayToSearchCriteriaArray(array $data): array {
+    $result = [];
+
+    foreach (self::$supported_keys as $key => $info) {
+      foreach ($info['possible_keys'] as $nominee) {
+        if (isset($data[$nominee])) {
+          $result[$key] = is_array($info['default_value']) ? (array)$data[$nominee] : $data[$nominee];
+          break;
+        }
+      }
+
+      if (!isset($result[$key])) {
+        $result[$key] = $info['default_value'];
+      }
+    }
+
+    return $result;
+  }
+
+}

--- a/test/SearchCriteriaTest.php
+++ b/test/SearchCriteriaTest.php
@@ -5,7 +5,9 @@ namespace Acquia\ContentHubClient\test;
 use PHPUnit\Framework\TestCase;
 use Acquia\ContentHubClient\SearchCriteria\Transformer;
 
-
+/**
+ * @coversDefaultClass \Acquia\ContentHubClient\SearchCriteria\Transformer
+ */
 class SearchCriteriaTest extends TestCase {
 
   /**
@@ -18,6 +20,9 @@ class SearchCriteriaTest extends TestCase {
    */
   private $expected;
 
+  /**
+   * @before
+   */
   public function setUp() {
     $this->data = [
       'search_term' => 'some-search-term',
@@ -65,14 +70,23 @@ class SearchCriteriaTest extends TestCase {
         ],
     ];
   }
-  public function test_result_when_all_keys_are_present_in_data(): void {
+
+  /**
+   * @covers ::arrayToSearchCriteriaArray
+   * @preserveGlobalState disabled
+   */
+  public function testResultWhenAllKeysArePresentInData(): void {
     $data = $this->data;
     $expected = $this->expected;
 
     self::assertEquals(Transformer::arrayToSearchCriteriaArray($data), $expected);
   }
 
-  public function test_missing_keys_get_default_values(): void {
+  /**
+   * @covers ::arrayToSearchCriteriaArray
+   * @preserveGlobalState disabled
+   */
+  public function testMissingKeysGetDefaultValues(): void {
     $data = $this->data;
     $expected = $this->expected;
 
@@ -84,7 +98,11 @@ class SearchCriteriaTest extends TestCase {
     self::assertEquals(Transformer::arrayToSearchCriteriaArray($data), $expected);
   }
 
-  public function test_keys_with_alternate_possible_keys_receive_correct_data(): void {
+  /**
+   * @covers ::arrayToSearchCriteriaArray
+   * @preserveGlobalState disabled
+   */
+  public function testKeysWithAlternatePossibleKeysReceiveCorrectData(): void {
     $data = $this->data;
     $expected = $this->expected;
 
@@ -101,7 +119,11 @@ class SearchCriteriaTest extends TestCase {
     self::assertEquals(Transformer::arrayToSearchCriteriaArray($data), $expected);
   }
 
-  public function test_if_default_value_is_array_value_will_always_be_array(): void {
+  /**
+   * @covers ::arrayToSearchCriteriaArray
+   * @preserveGlobalState disabled
+   */
+  public function testIfDefaultValueIsArrayValueWillAlwaysBeArray(): void {
     $data = $this->data;
     $expected = $this->expected;
 

--- a/test/SearchCriteriaTest.php
+++ b/test/SearchCriteriaTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Acquia\ContentHubClient\test;
+
+use PHPUnit\Framework\TestCase;
+use Acquia\ContentHubClient\SearchCriteria\Transformer;
+
+
+class SearchCriteriaTest extends TestCase {
+
+  /**
+   * @var array
+   */
+  private $data;
+
+  /**
+   * @var array
+   */
+  private $expected;
+
+  public function setUp() {
+    $this->data = [
+      'search_term' => 'some-search-term',
+      'type' => 'some-type',
+      'bundle' => 'some-bundle',
+      'tags' => 'some-tags',
+      'label' => 'some-label',
+      'start_date' => 'some-start_date',
+      'end_date' => 'some-end-date',
+      'from' => 'some-from',
+      'size' => 'some-size',
+      'sorting' => 'some-sort',
+      'version' => 'some-version',
+      'languages' => [
+        'some-language-1',
+        'some-language-2',
+      ],
+    ];
+
+    $this->expected = [
+      'search_term' => 'some-search-term',
+      'type' =>
+        [
+          0 => 'some-type',
+        ],
+      'bundle' =>
+        [
+          0 => 'some-bundle',
+        ],
+      'tags' =>
+        [
+          0 => 'some-tags',
+        ],
+      'label' => 'some-label',
+      'start_date' => 'some-start_date',
+      'end_date' => 'some-end-date',
+      'from' => 'some-from',
+      'size' => 'some-size',
+      'sorting' => '',
+      'version' => 'some-version',
+      'languages' =>
+        [
+          0 => 'some-language-1',
+          1 => 'some-language-2',
+        ],
+    ];
+  }
+  public function test_result_when_all_keys_are_present_in_data(): void {
+    $data = $this->data;
+    $expected = $this->expected;
+
+    self::assertEquals(Transformer::arrayToSearchCriteriaArray($data), $expected);
+  }
+
+  public function test_missing_keys_get_default_values(): void {
+    $data = $this->data;
+    $expected = $this->expected;
+
+    foreach (array_keys($this->data) as $non_existing_key) {
+      unset($data[$non_existing_key]);
+      $expected[$non_existing_key] = Transformer::$supported_keys[$non_existing_key]['default_value'];
+    }
+
+    self::assertEquals(Transformer::arrayToSearchCriteriaArray($data), $expected);
+  }
+
+  public function test_keys_with_alternate_possible_keys_receive_correct_data(): void {
+    $data = $this->data;
+    $expected = $this->expected;
+
+    $keys_with_alternate = [
+      'from' => 'start',
+      'size' => 'limit',
+    ];
+
+    foreach ($keys_with_alternate as $key => $alternate_key) {
+      $data[$alternate_key] = $data[$key];
+      unset($data[$key]);
+    }
+
+    self::assertEquals(Transformer::arrayToSearchCriteriaArray($data), $expected);
+  }
+
+  public function test_if_default_value_is_array_value_will_always_be_array(): void {
+    $data = $this->data;
+    $expected = $this->expected;
+
+    $data['languages'] = 'en';
+    $expected['languages'] = ['en'];
+
+    self::assertEquals(Transformer::arrayToSearchCriteriaArray($data), $expected);
+  }
+
+}


### PR DESCRIPTION
The aim is to add raw search criteria to a proprietary request header right before it gets sent to the server.
I tried to clean up and simplify former implementation in favor of more maintainable code. Also, I wrote unit test to cover all cases that came to my mind. Please feel free to point out any edge case that this implementation doesn't cover. 

You can run the unit test using the following command:
./vendor/phpunit/phpunit/phpunit -c phpunit.xml test/SearchCriteriaTest.php