### PR TITLE
LCH-3246: Use explicit conditional to exclude only NULL values

### DIFF
--- a/src/CDFAttribute.php
+++ b/src/CDFAttribute.php
@@ -86,7 +86,8 @@ class CDFAttribute
         }
         $this->id = $id;
         $this->type = $type;
-        if ($value) {
+
+        if ($value !== NULL) {
             $this->value[$language] = $value;
         }
     }


### PR DESCRIPTION
The previous form of the conditional, excluded all falsy values (e.g. 0, false, empty string, etc) values. We need an explicit conditional to factor them in, except for NULL.