### PR TITLE
LCH-3786: Fix calling variadic function with array; array should be unpacked

### DIFF
--- a/src/ObjectFactory.php
+++ b/src/ObjectFactory.php
@@ -77,7 +77,7 @@ class ObjectFactory {
   }
 
   public static function getCDFDocument(CDFObject ...$entities): CDFDocument {
-    return new CDFDocument($entities);
+    return new CDFDocument(...$entities);
   }
 
   public static function getWebhook(array $definition): Webhook {


### PR DESCRIPTION
Fix calling variadic function with array; array should be unpacked