### PR TITLE
LCH-3571: (2.x) Return DEPRECATED when logs method gets called

### DIFF
--- a/src/ContentHubClient.php
+++ b/src/ContentHubClient.php
@@ -39,11 +39,11 @@ class ContentHubClient extends Client {
 
   const OPTION_NAME_LANGUAGES = 'client-languages';
 
-  const FEATURE_DISCONTINUED_RESPONSE = [
+  const FEATURE_DEPRECATED_RESPONSE = [
       'success' => FALSE,
       'error' => [
         'code' => SymfonyResponse::HTTP_GONE,
-        'message' => 'This feature is discontinued',
+        'message' => 'This feature is deprecated',
       ],
   ];
 
@@ -540,11 +540,11 @@ class ContentHubClient extends Client {
    */
   public function logs($query = '', array $query_options = []) {
     return new Response(
-      self::FEATURE_DISCONTINUED_RESPONSE['error']['code'],
+      self::FEATURE_DEPRECATED_RESPONSE['error']['code'],
       [],
-      json_encode(self::FEATURE_DISCONTINUED_RESPONSE),
+      json_encode(self::FEATURE_DEPRECATED_RESPONSE),
       '1.1',
-      self::FEATURE_DISCONTINUED_RESPONSE['error']['message']
+      self::FEATURE_DEPRECATED_RESPONSE['error']['message']
     );
   }
 

--- a/src/ContentHubClient.php
+++ b/src/ContentHubClient.php
@@ -18,6 +18,7 @@ use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Exception\ServerException;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -37,6 +38,14 @@ class ContentHubClient extends Client {
   const LIBRARYNAME = 'AcquiaContentHubPHPLib';
 
   const OPTION_NAME_LANGUAGES = 'client-languages';
+
+  const FEATURE_DISCONTINUED_RESPONSE = [
+      'success' => FALSE,
+      'error' => [
+        'code' => SymfonyResponse::HTTP_GONE,
+        'message' => 'This feature is discontinued',
+      ],
+  ];
 
   /**
    * The settings.
@@ -530,15 +539,13 @@ class ContentHubClient extends Client {
    * @throws \GuzzleHttp\Exception\RequestException
    */
   public function logs($query = '', array $query_options = []) {
-    $query_options += [
-      'size' => 20,
-      'from' => 0,
-      'sort' => 'timestamp:desc',
-    ];
-    $options['body'] = empty($query) ? '{"query": {"match_all": {}}}' : $query;
-    $endpoint = 'history?' . http_build_query($query_options);
-    $response = $this->post($endpoint, $options);
-    return self::getResponseJson($response);
+    return new Response(
+      self::FEATURE_DISCONTINUED_RESPONSE['error']['code'],
+      [],
+      json_encode(self::FEATURE_DISCONTINUED_RESPONSE),
+      '1.1',
+      self::FEATURE_DISCONTINUED_RESPONSE['error']['message']
+    );
   }
 
   /**

--- a/test/ContentHubClientTest.php
+++ b/test/ContentHubClientTest.php
@@ -774,7 +774,7 @@ class ContentHubClientTest extends TestCase {
   public function testLogsReturnsDiscontinued(): void {
     $api_response = $this->ch_client->logs();
 
-    $body = $this->ch_client::FEATURE_DISCONTINUED_RESPONSE;
+    $body = $this->ch_client::FEATURE_DEPRECATED_RESPONSE;
     $this->assertEquals($body['error']['code'], $api_response->getStatusCode());
     $this->assertEquals($body['error']['message'], $api_response->getReasonPhrase());
     $this->assertEquals($body, json_decode($api_response->getBody()->getContents(), TRUE));


### PR DESCRIPTION
As part of retiring logs history feature from Plexus, this PR aims at returning DEPRECATED response when logs method gets called instead of hitting Plexus.

Subtask: https://backlog.acquia.com/browse/LCH-3571