### PR TITLE
http-hmac-php v6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "issues": "https://github.com/acquia/content-hub-php/issues"
     },
     "require": {
-        "acquia/http-hmac-php": "~3.4|~4.1.2",
+        "acquia/http-hmac-php": "~3.4|~6.0.0",
         "ext-json": "*",
         "php": ">=7.1",
         "psr/log": "~1.0",


### PR DESCRIPTION
We have some conflicts upgrading to PHP 8

<img width="1462" alt="image" src="https://user-images.githubusercontent.com/2011140/158564929-a55b7274-d700-4b29-a63a-47f25bfd37f6.png">
