### PR TITLE
LCH-6049: Updated version constant.

### DIFF
--- a/src/ContentHubClient.php
+++ b/src/ContentHubClient.php
@@ -28,7 +28,6 @@ use function GuzzleHttp\default_user_agent;
  */
 class ContentHubClient extends Client {
 
-  // Override VERSION inherited from GuzzleHttp::ClientInterface.
   const LIB_VERSION = '2.2.0';
 
   const LIBRARYNAME = 'AcquiaContentHubPHPLib';

--- a/src/ContentHubClient.php
+++ b/src/ContentHubClient.php
@@ -29,7 +29,7 @@ use function GuzzleHttp\default_user_agent;
 class ContentHubClient extends Client {
 
   // Override VERSION inherited from GuzzleHttp::ClientInterface.
-  const VERSION = '2.0.0';
+  const LIB_VERSION = '2.2.0';
 
   const LIBRARYNAME = 'AcquiaContentHubPHPLib';
 


### PR DESCRIPTION
Issue: https://backlog.acquia.com/browse/LCH-6049

Fetching deprecated class constant VERSION of class `Drupal\acquia_contenthub_server_test\Client\ContentHubClientMock:` Will be removed in Guzzle 7.0.0