### PR TITLE
LCH-6798: Handle exceptions which do not have response objects. 3.4.x

### DIFF
--- a/src/Logging/LoggingHelperTrait.php
+++ b/src/Logging/LoggingHelperTrait.php
@@ -35,7 +35,7 @@ trait LoggingHelperTrait {
    *  @codeCoverageIgnore
    */
   protected function getExceptionResponse(string $method, string $api_call, \Exception $exception): ResponseInterface {
-    $response = $exception->getResponse();
+    $response = method_exists($exception, 'getResponse') ? $exception->getResponse() : NULL;
     if (!$response) {
       $response = $this->getErrorResponse($exception->getCode(), $exception->getMessage());
     }

--- a/test/ContentHubClientTest.php
+++ b/test/ContentHubClientTest.php
@@ -350,7 +350,7 @@ class ContentHubClientTest extends TestCase {
     ];
     $log_message = 'Request ID: test-request-uuid, Method: GET, Path: "test-endpoint", Status Code: 202, Reason: some-reason, Error Code: , Error Message: "". Error data: "end-point-not-available"';
     $response_code = SymfonyResponse::HTTP_ACCEPTED;
-    $exception = \Mockery::mock(\Exception::class);
+    $exception = \Mockery::mock(RequestException::class);
     $exception->shouldReceive('getResponse')
       ->andReturn($this->makeMockResponse($response_code, [], json_encode($response_body)));
 
@@ -389,7 +389,7 @@ class ContentHubClientTest extends TestCase {
     ];
     $log_message = 'Resource not found in Content Hub: entities/random-uuid.';
     $response_code = SymfonyResponse::HTTP_NOT_FOUND;
-    $exception = \Mockery::mock(\Exception::class);
+    $exception = \Mockery::mock(RequestException::class);
     $exception->shouldReceive('getResponse')
       ->andReturn($this->makeMockResponse($response_code, [], json_encode($response_body)));
 


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #NNN

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->
