### PR TITLE
LCH-7069: Added getInterestList function and deprecated getInterestsByWebhook and getInterestsByWebhookAndSiteRole.

### DIFF
--- a/src/ContentHubClient.php
+++ b/src/ContentHubClient.php
@@ -747,6 +747,8 @@ class ContentHubClient implements ClientInterface {
    * @return array
    *   Interests list.
    *
+   * @deprecated use getInterestList().
+   *
    * @throws \Exception
    */
   public function getInterestsByWebhook(string $webhook_uuid): array {
@@ -804,14 +806,53 @@ class ContentHubClient implements ClientInterface {
    * @return array
    *   An associate array keyed by the entity uuid.
    *
+   * @deprecated use getInterestList().
+   *
    * @throws \Exception
    */
   public function getInterestsByWebhookAndSiteRole(string $webhook_uuid, string $site_role, ?bool $disable_syndication = NULL): array {
-    $options = [];
     if (isset($disable_syndication)) {
-      $options['query'] = [
-        'disable_syndication' => $disable_syndication,
-      ];
+      return $this->getInterestList($webhook_uuid, $site_role, ['disable_syndication' => $disable_syndication]);
+    }
+    return $this->getInterestList($webhook_uuid, $site_role);
+  }
+
+  /**
+   * Returns an interest list based on the site role and query parameters.
+   *
+   * @param string $webhook_uuid
+   *   Identifier of the webhook.
+   * @param string $site_role
+   *   The role of the site.
+   * @param array $query
+   *   Query params. Accepts disable_syndication, size, from and uuids.
+   *
+   * @code
+   *   disable_syndication: boolean.
+   *     Filter for disabled entities.
+   *     If set to true, only disabled entities will be returned.
+   *     If set to false, only enabled entities will be returned.
+   *     If not set, all the entities will be returned.
+   *   size: integer.
+   *     Size of the interest list items to return.
+   *     Max is 3000. Min is 1.
+   *   from: integer.
+   *     This is the offset value.
+   *     Must be positive integer.
+   *   uuids: string.
+   *     This are the comma seprated uuid values.
+   *     Max 3000 uuids can be passed.
+   * @endcode
+   *
+   * @return array
+   *   An associate array keyed by the entity uuid.
+   *
+   * @throws \Exception
+   */
+  public function getInterestList(string $webhook_uuid, string $site_role, array $query = []): array {
+    $options = [];
+    if (!empty($query)) {
+      $options['query'] = $query;
     }
     $data = self::getResponseJson($this->get("interest/webhook/$webhook_uuid/$site_role", $options));
     return $data['data'] ?? [];

--- a/src/ContentHubClient.php
+++ b/src/ContentHubClient.php
@@ -747,7 +747,8 @@ class ContentHubClient implements ClientInterface {
    * @return array
    *   Interests list.
    *
-   * @deprecated use getInterestList().
+   * @deprecated in 3.5.3 and is removed from 3.6.0. Use getInterestList().
+   * @see getInterestList()
    *
    * @throws \Exception
    */
@@ -806,7 +807,8 @@ class ContentHubClient implements ClientInterface {
    * @return array
    *   An associate array keyed by the entity uuid.
    *
-   * @deprecated use getInterestList().
+   * @deprecated in 3.5.3 and is removed from 3.6.0. Use getInterestList().
+   * @see getInterestList()
    *
    * @throws \Exception
    */

--- a/test/ContentHubClientTest.php
+++ b/test/ContentHubClientTest.php
@@ -1487,7 +1487,12 @@ class ContentHubClientTest extends TestCase {
     $this->ch_client
       ->shouldReceive('get')
       ->once()
-      ->with("interest/webhook/$webhook_uuid/$site_role", ['query' => ['size' => 1, 'from' => 1]])
+      ->with("interest/webhook/$webhook_uuid/$site_role", [
+        'query' => [
+          'size' => 1,
+          'from' => 1,
+        ],
+      ])
       ->andReturn($this->makeMockResponse(SymfonyResponse::HTTP_OK, [], json_encode($response)));
 
     $query = [

--- a/test/ContentHubClientTest.php
+++ b/test/ContentHubClientTest.php
@@ -1362,9 +1362,9 @@ class ContentHubClientTest extends TestCase {
   }
 
   /**
-   * @covers ::getInterestsByWebhookAndSiteRole
+   * @covers ::getInterestList
    */
-  public function testGetInterestsByWebhookAndSiteRoleIfAny(): void {
+  public function testGetInterestsListIfAny(): void {
     $response = [
       'success' => TRUE,
       'data' => [
@@ -1383,13 +1383,13 @@ class ContentHubClientTest extends TestCase {
       ->with("interest/webhook/$webhook_uuid/$site_role", [])
       ->andReturn($this->makeMockResponse(SymfonyResponse::HTTP_OK, [], json_encode($response)));
 
-    $this->assertSame($this->ch_client->getInterestsByWebhookAndSiteRole($webhook_uuid, $site_role), $response['data']);
+    $this->assertSame($this->ch_client->getInterestList($webhook_uuid, $site_role), $response['data']);
   }
 
   /**
-   * @covers ::getInterestsByWebhookAndSiteRole
+   * @covers ::getInterestList
    */
-  public function testGetInterestsByWebhookAndSiteRoleIfNone(): void {
+  public function testGetInterestsListIfNone(): void {
     $response = [
       'success' => FALSE,
       'error' => [
@@ -1406,13 +1406,13 @@ class ContentHubClientTest extends TestCase {
       ->with("interest/webhook/$webhook_uuid/$site_role", [])
       ->andReturn($this->makeMockResponse(SymfonyResponse::HTTP_OK, [], json_encode($response)));
 
-    $this->assertSame($this->ch_client->getInterestsByWebhookAndSiteRole($webhook_uuid, $site_role), []);
+    $this->assertSame($this->ch_client->getInterestList($webhook_uuid, $site_role), []);
   }
 
   /**
-   * @covers ::getInterestsByWebhookAndSiteRole
+   * @covers ::getInterestList
    */
-  public function testGetDisabledInterestsByWebhookAndSiteRoleIfAny(): void {
+  public function testGetDisabledInterestsListIfAny(): void {
     $response = [
       'success' => TRUE,
       'data' => [
@@ -1432,13 +1432,16 @@ class ContentHubClientTest extends TestCase {
       ->with("interest/webhook/$webhook_uuid/$site_role", ['query' => ['disable_syndication' => TRUE]])
       ->andReturn($this->makeMockResponse(SymfonyResponse::HTTP_OK, [], json_encode($response)));
 
-    $this->assertSame($this->ch_client->getInterestsByWebhookAndSiteRole($webhook_uuid, $site_role, TRUE), $response['data']);
+    $query = [
+      'disable_syndication' => TRUE,
+    ];
+    $this->assertSame($this->ch_client->getInterestList($webhook_uuid, $site_role, $query), $response['data']);
   }
 
   /**
-   * @covers ::getInterestsByWebhookAndSiteRole
+   * @covers ::getInterestList
    */
-  public function testGetEnabledInterestsByWebhookAndSiteRoleIfAny(): void {
+  public function testGetEnabledInterestsListIfAny(): void {
     $response = [
       'success' => TRUE,
       'data' => [
@@ -1458,7 +1461,69 @@ class ContentHubClientTest extends TestCase {
       ->with("interest/webhook/$webhook_uuid/$site_role", ['query' => ['disable_syndication' => FALSE]])
       ->andReturn($this->makeMockResponse(SymfonyResponse::HTTP_OK, [], json_encode($response)));
 
-    $this->assertSame($this->ch_client->getInterestsByWebhookAndSiteRole($webhook_uuid, $site_role, FALSE), $response['data']);
+    $query = [
+      'disable_syndication' => FALSE,
+    ];
+    $this->assertSame($this->ch_client->getInterestList($webhook_uuid, $site_role, $query), $response['data']);
+  }
+
+  /**
+   * @covers ::getInterestList
+   */
+  public function testGetInterestsListBySizeAndFrom(): void {
+    $response = [
+      'success' => TRUE,
+      'data' => [
+        '0e714009-72f9-4016-8f26-5fae32e6abb8' => [
+          'status' => SyndicationStatus::IMPORT_SUCCESSFUL,
+          'reason' => 'ipsum',
+          'event_ref' => '0e714009-72f9-4016-8f26-5fae32e6abb9',
+          'disabled_syndication' => FALSE,
+        ],
+      ],
+    ];
+    $webhook_uuid = 'some-webhook-uuid';
+    $site_role = 'subscriber';
+    $this->ch_client
+      ->shouldReceive('get')
+      ->once()
+      ->with("interest/webhook/$webhook_uuid/$site_role", ['query' => ['size' => 1, 'from' => 1]])
+      ->andReturn($this->makeMockResponse(SymfonyResponse::HTTP_OK, [], json_encode($response)));
+
+    $query = [
+      'size' => 1,
+      'from' => 1,
+    ];
+    $this->assertSame($this->ch_client->getInterestList($webhook_uuid, $site_role, $query), $response['data']);
+  }
+
+  /**
+   * @covers ::getInterestList
+   */
+  public function testGetInterestsListByUuids(): void {
+    $response = [
+      'success' => TRUE,
+      'data' => [
+        '0e714009-72f9-4016-8f26-5fae32e6abb8' => [
+          'status' => SyndicationStatus::IMPORT_SUCCESSFUL,
+          'reason' => 'ipsum',
+          'event_ref' => '0e714009-72f9-4016-8f26-5fae32e6abb9',
+          'disabled_syndication' => FALSE,
+        ],
+      ],
+    ];
+    $webhook_uuid = 'some-webhook-uuid';
+    $site_role = 'subscriber';
+    $this->ch_client
+      ->shouldReceive('get')
+      ->once()
+      ->with("interest/webhook/$webhook_uuid/$site_role", ['query' => ['uuids' => '0e714009-72f9-4016-8f26-5fae32e6abb8']])
+      ->andReturn($this->makeMockResponse(SymfonyResponse::HTTP_OK, [], json_encode($response)));
+
+    $query = [
+      'uuids' => '0e714009-72f9-4016-8f26-5fae32e6abb8'
+    ];
+    $this->assertSame($this->ch_client->getInterestList($webhook_uuid, $site_role, $query), $response['data']);
   }
 
   /**


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #NNN

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->
